### PR TITLE
Only wait for process handle

### DIFF
--- a/less.c
+++ b/less.c
@@ -230,8 +230,7 @@ int wmain(int argc, wchar_t** argv)
 				if (CreateProcessW(editor, cmdLine, NULL, NULL, TRUE, 0, NULL, NULL, &startup, &info))
 				{
 					DWORD dw;
-
-					WaitForSingleObject(info.hThread, INFINITE);
+					
 					WaitForSingleObject(info.hProcess, INFINITE);
 
 					if (GetExitCodeProcess(info.hProcess, &dw))


### PR DESCRIPTION
The process handle is only signalled after all threads have stopped, waiting for the thread first is pointless.